### PR TITLE
Alpine image support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
       steps {
         sh '''
           curl -O $HELM_URL/$HELM_TARBALL
-          tar xzfv $HELM_TARBALL -C /home/jenkins && rm $HELM_TARBALL
-          PATH=/home/jenkins/linux-amd64/:$PATH
+          tar xzfv $HELM_TARBALL -C ${JENKINS_HOME} && rm $HELM_TARBALL
+          PATH=${JENKINS_HOME}/linux-amd64/:$PATH
           helm init --client-only
 
           if helm status pr-env-$GITHUB_PR_NUMBER > /dev/null 2>&1; then
@@ -49,8 +49,8 @@ pipeline {
       steps {
         sh '''
           curl -O $HELM_URL/$HELM_TARBALL
-          tar xzfv $HELM_TARBALL -C /home/jenkins && rm $HELM_TARBALL
-          PATH=/home/jenkins/linux-amd64/:$PATH
+          tar xzfv $HELM_TARBALL -C ${JENKINS_HOME} && rm $HELM_TARBALL
+          PATH=${JENKINS_HOME}/linux-amd64/:$PATH
           helm init --client-only
 
           # Minikube requires persistence to be disabled.
@@ -97,8 +97,8 @@ EOF
           DEPLOY_ID=$(cat DEPLOY_ID.txt)
 
           curl -O $HELM_URL/$HELM_TARBALL
-          tar xzfv $HELM_TARBALL -C /home/jenkins && rm $HELM_TARBALL
-          PATH=/home/jenkins/linux-amd64/:$PATH
+          tar xzfv $HELM_TARBALL -C ${JENKINS_HOME} && rm $HELM_TARBALL
+          PATH=${JENKINS_HOME}/linux-amd64/:$PATH
           helm init --client-only
 
           # Update the GitHub deploy status accordingly.


### PR DESCRIPTION
When the helm image tag is a Jenkins Alpine image, the hard-coded Jenkins path doesn't work:
```yaml
ImageTag: 2.98-alpine
```

This PR fixes the below error:
```sh
[test] Running shell script
+ curl -O https://storage.googleapis.com/kubernetes-helm/helm-v2.2.0-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 11.8M  100 11.8M    0     0  11.8M      0  0:00:01 --:--:--  0:00:01 62.9M
+ tar xzfv helm-v2.2.0-linux-amd64.tar.gz -C /home/jenkins
tar: can't change directory to '/home/jenkins': No such file or directory
+ PATH=/home/jenkins/linux-amd64/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
+ helm init --client-only
/var/jenkins_home/workspace/test@tmp/durable-d2232c7c/script.sh: line 1: helm: not found
```